### PR TITLE
[Task]: replace deprecated `initPayment` references and usages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-#Changelog
+## Changelog
+### 2.0
+- Removed deprecated `initPayment` method.
 
 ### 1.0.5
-Added deprecation trigger to `initPayment`, which is [deprecated and removed](https://github.com/pimcore/pimcore/blob/478c011b8dd4b2e8fd5e1e0739da7a0898a31273/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md?plain=1#L665) since Pimcore 10. In 2.0 it will be replaced by `createOrder`
+- Added deprecation trigger to `initPayment`, which is [deprecated and removed](https://github.com/pimcore/pimcore/blob/478c011b8dd4b2e8fd5e1e0739da7a0898a31273/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md?plain=1#L665) since Pimcore 10. In 2.0 it will be replaced by `createOrder`

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Integrate PayPal payment button and overwrite a few methods like in the sample. 
 
 4) Create a startPaymentAction in your controller
 
-Initialize checkout manager, call `startOrderPayment` and then `initPayment` of the payment 
+Initialize checkout manager, call `startOrderPaymentWithPaymentProvider` of the payment 
 implementation. It is creating an order at PayPal and its response is the default PayPal 
 response, which need to be returned as a json response of the action.  
 

--- a/src/PaymentManager/Payment/PayPalSmartPaymentButton.php
+++ b/src/PaymentManager/Payment/PayPalSmartPaymentButton.php
@@ -102,7 +102,7 @@ class PayPalSmartPaymentButton extends AbstractPayment implements PaymentInterfa
     /**
      * Creates a new PayPal Order
      */
-    private function createOrder(PriceInterface $price, array $config): mixed
+    public function createOrder(PriceInterface $price, array $config): mixed
     {
         // check params
         $required = [

--- a/src/PaymentManager/Payment/PayPalSmartPaymentButton.php
+++ b/src/PaymentManager/Payment/PayPalSmartPaymentButton.php
@@ -100,15 +100,9 @@ class PayPalSmartPaymentButton extends AbstractPayment implements PaymentInterfa
     }
 
     /**
-     * Start payment
-     *
-     * @param PriceInterface $price
-     * @param array $config
-     *
-     * @return mixed - either an url for a link the user has to follow to (e.g. paypal) or
-     *                 an symfony form builder which needs to submitted (e.g. datatrans and wirecard)
+     * Creates a new PayPal Order
      */
-    public function initPayment(PriceInterface $price, array $config)
+    private function createOrder(PriceInterface $price, array $config): mixed
     {
         // check params
         $required = [
@@ -166,7 +160,7 @@ class PayPalSmartPaymentButton extends AbstractPayment implements PaymentInterfa
      */
     public function startPayment(OrderAgentInterface $orderAgent, PriceInterface $price, AbstractRequest $config): StartPaymentResponseInterface
     {
-        $result = $this->initPayment($price, $config->asArray());
+        $result = $this->createOrder($price, $config->asArray());
 
         if ($result instanceof \stdClass) {
             if ($json = json_encode($result)) {
@@ -179,7 +173,7 @@ class PayPalSmartPaymentButton extends AbstractPayment implements PaymentInterfa
             return new JsonResponse($orderAgent->getOrder(), $result);
         }
 
-        throw new \Exception('result of initPayment neither stdClass nor JSON');
+        throw new \Exception('The created order is neither stdClass nor JSON');
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/pimcore/payment-provider-paypal-smart-payment-button/issues/1