### PR TITLE
[Task]: Add deprecation for initPayment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 #Changelog
 
 ### 1.0.5
-Added deprecation trigger to `initPayment`, which is [deprecated and removed](https://github.com/pimcore/pimcore/blob/478c011b8dd4b2e8fd5e1e0739da7a0898a31273/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md?plain=1#L665) since Pimcore 10.
+Added deprecation trigger to `initPayment`, which is [deprecated and removed](https://github.com/pimcore/pimcore/blob/478c011b8dd4b2e8fd5e1e0739da7a0898a31273/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md?plain=1#L665) since Pimcore 10. In 2.0 it will be replaced by `createOrder`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+#Changelog
+
+### 1.0.5
+Added deprecation trigger to `initPayment`, which is [deprecated and removed](https://github.com/pimcore/pimcore/blob/478c011b8dd4b2e8fd5e1e0739da7a0898a31273/doc/Development_Documentation/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md?plain=1#L665) since Pimcore 10.

--- a/src/PaymentManager/Payment/PayPalSmartPaymentButton.php
+++ b/src/PaymentManager/Payment/PayPalSmartPaymentButton.php
@@ -114,6 +114,7 @@ class PayPalSmartPaymentButton extends AbstractPayment implements PaymentInterfa
     {
         return $this->createOrder($price, $config);
     }
+
     /**
      * Creates a new PayPal Order
      */

--- a/src/PaymentManager/Payment/PayPalSmartPaymentButton.php
+++ b/src/PaymentManager/Payment/PayPalSmartPaymentButton.php
@@ -108,7 +108,7 @@ class PayPalSmartPaymentButton extends AbstractPayment implements PaymentInterfa
      * @return mixed - either an url for a link the user has to follow to (e.g. paypal) or
      *                 an symfony form builder which needs to submitted (e.g. datatrans and wirecard)
      *
-     * @deprecated since it was removed from Pimcore 10. This method will be renamed in pimcore/payment-provider-paypal-smart-payment-button 2.0, please see PR #16.
+     * @deprecated since it was removed from Pimcore 10. This method will be replaced by "createOrder".
      */
     public function initPayment(PriceInterface $price, array $config)
     {

--- a/src/PaymentManager/Payment/PayPalSmartPaymentButton.php
+++ b/src/PaymentManager/Payment/PayPalSmartPaymentButton.php
@@ -108,9 +108,16 @@ class PayPalSmartPaymentButton extends AbstractPayment implements PaymentInterfa
      * @return mixed - either an url for a link the user has to follow to (e.g. paypal) or
      *                 an symfony form builder which needs to submitted (e.g. datatrans and wirecard)
      *
-     * @deprecated since it was removed from Pimcore 10. This method will be replaced by "createOrder".
+     * @deprecated since it was removed from Pimcore 10. This method is replaced by "createOrder".
      */
     public function initPayment(PriceInterface $price, array $config)
+    {
+        return $this->createOrder($price, $config);
+    }
+    /**
+     * Creates a new PayPal Order
+     */
+    public function createOrder(PriceInterface $price, array $config): mixed
     {
         // check params
         $required = [

--- a/src/PaymentManager/Payment/PayPalSmartPaymentButton.php
+++ b/src/PaymentManager/Payment/PayPalSmartPaymentButton.php
@@ -107,6 +107,8 @@ class PayPalSmartPaymentButton extends AbstractPayment implements PaymentInterfa
      *
      * @return mixed - either an url for a link the user has to follow to (e.g. paypal) or
      *                 an symfony form builder which needs to submitted (e.g. datatrans and wirecard)
+     *
+     * @deprecated since it was removed from Pimcore 10. This method will be renamed in pimcore/payment-provider-paypal-smart-payment-button 2.0, please see PR #16.
      */
     public function initPayment(PriceInterface $price, array $config)
     {


### PR DESCRIPTION
Related #1

Not sure if we should add the trigger to log the deprecation, as the initPayment getting removed from Core doesn't affect this bundle, it turns into an own custom method, instead of something implemented and required by the interface. 
In #16, just renamed it to avoid confusion. 